### PR TITLE
[enhancement] Rework scheduler for a better API

### DIFF
--- a/wpilib-macros/src/lib.rs
+++ b/wpilib-macros/src/lib.rs
@@ -353,8 +353,8 @@ pub fn subsystem(input: TokenStream) -> TokenStream {
                 let mut this = #struct_name_caps.lock();
                 this
             }
-            pub fn suid() -> usize {
-                SUID as usize
+            pub fn suid() -> u8 {
+                SUID as u8
             }
             pub fn name() -> &'static str {
                 stringify!(#struct_name)

--- a/wpilib-macros/src/lib.rs
+++ b/wpilib-macros/src/lib.rs
@@ -353,8 +353,8 @@ pub fn subsystem(input: TokenStream) -> TokenStream {
                 let mut this = #struct_name_caps.lock();
                 this
             }
-            pub fn suid() -> u8 {
-                SUID as u8
+            pub fn suid() -> usize {
+                SUID as usize
             }
             pub fn name() -> &'static str {
                 stringify!(#struct_name)

--- a/wpilib/src/command/commands.rs
+++ b/wpilib/src/command/commands.rs
@@ -1,4 +1,3 @@
-use crate::command;
 use std::{collections::HashSet, fmt::Debug};
 
 pub trait CommandTrait {
@@ -12,9 +11,9 @@ pub trait CommandTrait {
         false
     }
 
-    // fn add_requirements(&mut self, _subsystems: Vec<u8>) {}
+    // fn add_requirements(&mut self, _subsystems: Vec<usize>) {}
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         Vec::new()
     }
 
@@ -37,12 +36,11 @@ pub struct CommandBuilder {
     periodic: Option<Box<dyn FnMut()>>,
     end: Option<Box<dyn FnMut(bool)>>,
     is_finished: Option<Box<dyn FnMut() -> bool>>,
-    requirements: Vec<u8>,
+    requirements: Vec<usize>,
 }
 
 impl CommandBuilder {
-    #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             init: None,
             periodic: None,
@@ -52,37 +50,31 @@ impl CommandBuilder {
         }
     }
 
-    #[must_use]
     pub fn init(mut self, init: impl FnMut() + 'static) -> Self {
         self.init = Some(Box::new(init));
         self
     }
 
-    #[must_use]
     pub fn periodic(mut self, periodic: impl FnMut() + 'static) -> Self {
         self.periodic = Some(Box::new(periodic));
         self
     }
 
-    #[must_use]
     pub fn end(mut self, end: impl FnMut(bool) + 'static) -> Self {
         self.end = Some(Box::new(end));
         self
     }
 
-    #[must_use]
     pub fn is_finished(mut self, is_finished: impl FnMut() -> bool + 'static) -> Self {
         self.is_finished = Some(Box::new(is_finished));
         self
     }
 
-    #[must_use]
-    pub fn with_requirements(mut self, requirements: Vec<u8>) -> Self {
+    pub fn with_requirements(mut self, requirements: Vec<usize>) -> Self {
         self.requirements = requirements;
         self
     }
 
-    #[must_use]
     pub fn build(self) -> Command {
         Command::Simple(SimpleBuiltCommand {
             init: self.init,
@@ -95,30 +87,33 @@ impl CommandBuilder {
 }
 
 impl CommandBuilder {
-    pub fn start_only(init: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
-        Self::new()
+    pub fn start_only(init: impl FnMut() + 'static, requirements: Vec<usize>) -> Command {
+        CommandBuilder::new()
             .init(init)
             .with_requirements(requirements)
             .build()
     }
 
-    pub fn run_only(periodic: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
-        Self::new()
+    pub fn run_only(periodic: impl FnMut() + 'static, requirements: Vec<usize>) -> Command {
+        CommandBuilder::new()
             .periodic(periodic)
             .with_requirements(requirements)
             .build()
     }
 
-    pub fn end_only(end: impl FnMut(bool) + 'static, requirements: Vec<u8>) -> Command {
-        Self::new().end(end).with_requirements(requirements).build()
+    pub fn end_only(end: impl FnMut(bool) + 'static, requirements: Vec<usize>) -> Command {
+        CommandBuilder::new()
+            .end(end)
+            .with_requirements(requirements)
+            .build()
     }
 
     pub fn run_start(
         init: impl FnMut() + 'static,
         periodic: impl FnMut() + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .init(init)
             .periodic(periodic)
             .with_requirements(requirements)
@@ -128,9 +123,9 @@ impl CommandBuilder {
     pub fn run_end(
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .periodic(periodic)
             .end(end)
             .with_requirements(requirements)
@@ -140,9 +135,9 @@ impl CommandBuilder {
     pub fn start_end(
         init: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .init(init)
             .end(end)
             .with_requirements(requirements)
@@ -153,9 +148,9 @@ impl CommandBuilder {
         init: impl FnMut() + 'static,
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .init(init)
             .periodic(periodic)
             .end(end)
@@ -166,9 +161,9 @@ impl CommandBuilder {
     pub fn run_until(
         is_finished: impl FnMut() -> bool + 'static,
         periodic: impl FnMut() + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .is_finished(is_finished)
             .periodic(periodic)
             .with_requirements(requirements)
@@ -179,9 +174,9 @@ impl CommandBuilder {
         is_finished: impl FnMut() -> bool + 'static,
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .is_finished(is_finished)
             .periodic(periodic)
             .end(end)
@@ -192,9 +187,9 @@ impl CommandBuilder {
     pub fn start_run_until(
         init: impl FnMut() + 'static,
         is_finished: impl FnMut() -> bool + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .init(init)
             .is_finished(is_finished)
             .with_requirements(requirements)
@@ -206,9 +201,9 @@ impl CommandBuilder {
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
         is_finished: impl FnMut() -> bool + 'static,
-        requirements: Vec<u8>,
+        requirements: Vec<usize>,
     ) -> Command {
-        Self::new()
+        CommandBuilder::new()
             .init(init)
             .periodic(periodic)
             .end(end)
@@ -223,7 +218,7 @@ pub struct SimpleBuiltCommand {
     periodic: Option<Box<dyn FnMut()>>,
     end: Option<Box<dyn FnMut(bool)>>,
     is_finished: Option<Box<dyn FnMut() -> bool>>,
-    requirements: Vec<u8>,
+    requirements: Vec<usize>,
 }
 impl CommandTrait for SimpleBuiltCommand {
     fn init(&mut self) {
@@ -245,12 +240,14 @@ impl CommandTrait for SimpleBuiltCommand {
     }
 
     fn is_finished(&mut self) -> bool {
-        self.is_finished
-            .as_mut()
-            .map_or(false, |is_finished| is_finished())
+        if let Some(is_finished) = self.is_finished.as_mut() {
+            is_finished()
+        } else {
+            false
+        }
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         self.requirements.clone()
     }
 }
@@ -270,12 +267,12 @@ impl Debug for SimpleBuiltCommand {
 pub struct ParallelBuiltCommand {
     commands: Vec<Command>,
     finished: Vec<bool>,
-    requirements: HashSet<u8>,
+    requirements: HashSet<usize>,
     race: bool,
 }
 impl CommandTrait for ParallelBuiltCommand {
     fn init(&mut self) {
-        for command in &mut self.commands {
+        for command in self.commands.iter_mut() {
             command.init();
         }
     }
@@ -304,21 +301,21 @@ impl CommandTrait for ParallelBuiltCommand {
     }
 
     fn is_finished(&mut self) -> bool {
-        if self.race {
-            self.finished.iter().any(|&finished| finished)
-        } else {
+        if !self.race {
             self.finished.iter().all(|&finished| finished)
+        } else {
+            self.finished.iter().any(|&finished| finished)
         }
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         self.requirements.clone().into_iter().collect()
     }
 
     fn get_name(&self) -> String {
         self.commands
             .iter()
-            .map(command::commands::CommandTrait::get_name)
+            .map(|command| command.get_name())
             .collect::<Vec<_>>()
             .join(",")
     }
@@ -329,7 +326,7 @@ impl CommandTrait for ParallelBuiltCommand {
 pub struct SequentialCommand {
     commands: Vec<Command>,
     current: usize,
-    requirements: HashSet<u8>,
+    requirements: HashSet<usize>,
 }
 impl CommandTrait for SequentialCommand {
     fn init(&mut self) {
@@ -349,9 +346,9 @@ impl CommandTrait for SequentialCommand {
 
     fn end(&mut self, interrupted: bool) {
         if interrupted {
-            if let Some(command) = self.commands.get_mut(self.current) {
-                command.end(true)
-            }
+            self.commands
+                .get_mut(self.current)
+                .map(|command| command.end(true));
         }
     }
 
@@ -359,14 +356,14 @@ impl CommandTrait for SequentialCommand {
         self.current >= self.commands.len()
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         self.requirements.clone().into_iter().collect()
     }
 
     fn get_name(&self) -> String {
         self.commands
             .iter()
-            .map(command::commands::CommandTrait::get_name)
+            .map(|command| command.get_name())
             .collect::<Vec<_>>()
             .join("->")
     }
@@ -396,7 +393,7 @@ impl CommandTrait for ProxyCommand {
         self.command.as_mut().unwrap().is_finished()
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         self.command.as_ref().unwrap().get_requirements()
     }
 
@@ -435,7 +432,7 @@ impl CommandTrait for WaitCommand {
         self.start_instant.unwrap().elapsed() >= self.duration
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         vec![]
     }
 
@@ -466,7 +463,7 @@ impl CommandTrait for NamedCommand {
         self.command.is_finished()
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         self.command.get_requirements()
     }
 
@@ -487,101 +484,99 @@ pub enum Command {
 impl Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            Self::Parallel(command) => f
+            Command::Parallel(command) => f
                 .debug_struct("Parallel")
                 .field("command", command)
                 .finish(),
-            Self::Sequential(command) => f
+            Command::Sequential(command) => f
                 .debug_struct("Sequential")
                 .field("command", command)
                 .finish(),
-            Self::Simple(command) => f.debug_struct("Simple").field("command", command).finish(),
-            Self::Custom(_) => f.debug_struct("Custom").finish(),
-            Self::Named(command) => f.debug_struct("Named").field("command", command).finish(),
-            Self::Wait(command) => f.debug_struct("Wait").field("command", command).finish(),
-            Self::Proxy(command) => f.debug_struct("Proxy").field("command", command).finish(),
+            Command::Simple(command) => f.debug_struct("Simple").field("command", command).finish(),
+            Command::Custom(_) => f.debug_struct("Custom").finish(),
+            Command::Named(command) => f.debug_struct("Named").field("command", command).finish(),
+            Command::Wait(command) => f.debug_struct("Wait").field("command", command).finish(),
+            Command::Proxy(command) => f.debug_struct("Proxy").field("command", command).finish(),
         }
     }
 }
 impl CommandTrait for Command {
     fn init(&mut self) {
         match self {
-            Self::Parallel(command) => command.init(),
-            Self::Sequential(command) => command.init(),
-            Self::Simple(command) => command.init(),
-            Self::Custom(command) => command.init(),
-            Self::Named(command) => command.init(),
-            Self::Wait(command) => command.init(),
-            Self::Proxy(command) => command.init(),
+            Command::Parallel(command) => command.init(),
+            Command::Sequential(command) => command.init(),
+            Command::Simple(command) => command.init(),
+            Command::Custom(command) => command.init(),
+            Command::Named(command) => command.init(),
+            Command::Wait(command) => command.init(),
+            Command::Proxy(command) => command.init(),
         }
     }
 
     fn periodic(&mut self) {
         match self {
-            Self::Parallel(command) => command.periodic(),
-            Self::Sequential(command) => command.periodic(),
-            Self::Simple(command) => command.periodic(),
-            Self::Custom(command) => command.periodic(),
-            Self::Named(command) => command.periodic(),
-            Self::Wait(command) => command.periodic(),
-            Self::Proxy(command) => command.periodic(),
+            Command::Parallel(command) => command.periodic(),
+            Command::Sequential(command) => command.periodic(),
+            Command::Simple(command) => command.periodic(),
+            Command::Custom(command) => command.periodic(),
+            Command::Named(command) => command.periodic(),
+            Command::Wait(command) => command.periodic(),
+            Command::Proxy(command) => command.periodic(),
         }
     }
 
     fn end(&mut self, interrupted: bool) {
         match self {
-            Self::Parallel(command) => command.end(interrupted),
-            Self::Sequential(command) => command.end(interrupted),
-            Self::Simple(command) => command.end(interrupted),
-            Self::Custom(command) => command.end(interrupted),
-            Self::Named(command) => command.end(interrupted),
-            Self::Wait(command) => command.end(interrupted),
-            Self::Proxy(command) => command.end(interrupted),
+            Command::Parallel(command) => command.end(interrupted),
+            Command::Sequential(command) => command.end(interrupted),
+            Command::Simple(command) => command.end(interrupted),
+            Command::Custom(command) => command.end(interrupted),
+            Command::Named(command) => command.end(interrupted),
+            Command::Wait(command) => command.end(interrupted),
+            Command::Proxy(command) => command.end(interrupted),
         }
     }
 
     fn is_finished(&mut self) -> bool {
         match self {
-            Self::Parallel(command) => command.is_finished(),
-            Self::Sequential(command) => command.is_finished(),
-            Self::Simple(command) => command.is_finished(),
-            Self::Custom(command) => command.is_finished(),
-            Self::Named(command) => command.is_finished(),
-            Self::Wait(command) => command.is_finished(),
-            Self::Proxy(command) => command.is_finished(),
+            Command::Parallel(command) => command.is_finished(),
+            Command::Sequential(command) => command.is_finished(),
+            Command::Simple(command) => command.is_finished(),
+            Command::Custom(command) => command.is_finished(),
+            Command::Named(command) => command.is_finished(),
+            Command::Wait(command) => command.is_finished(),
+            Command::Proxy(command) => command.is_finished(),
         }
     }
 
-    fn get_requirements(&self) -> Vec<u8> {
+    fn get_requirements(&self) -> Vec<usize> {
         match self {
-            Self::Parallel(command) => command.get_requirements(),
-            Self::Sequential(command) => command.get_requirements(),
-            Self::Simple(command) => command.get_requirements(),
-            Self::Custom(command) => command.get_requirements(),
-            Self::Named(command) => command.get_requirements(),
-            Self::Wait(command) => command.get_requirements(),
-            Self::Proxy(command) => command.get_requirements(),
+            Command::Parallel(command) => command.get_requirements(),
+            Command::Sequential(command) => command.get_requirements(),
+            Command::Simple(command) => command.get_requirements(),
+            Command::Custom(command) => command.get_requirements(),
+            Command::Named(command) => command.get_requirements(),
+            Command::Wait(command) => command.get_requirements(),
+            Command::Proxy(command) => command.get_requirements(),
         }
     }
 
     fn get_name(&self) -> String {
         match self {
-            Self::Parallel(command) => command.get_name(),
-            Self::Sequential(command) => command.get_name(),
-            Self::Simple(command) => command.get_name(),
-            Self::Custom(command) => command.get_name(),
-            Self::Named(command) => command.get_name(),
-            Self::Wait(command) => command.get_name(),
-            Self::Proxy(command) => command.get_name(),
+            Command::Parallel(command) => command.get_name(),
+            Command::Sequential(command) => command.get_name(),
+            Command::Simple(command) => command.get_name(),
+            Command::Custom(command) => command.get_name(),
+            Command::Named(command) => command.get_name(),
+            Command::Wait(command) => command.get_name(),
+            Command::Proxy(command) => command.get_name(),
         }
     }
 }
 unsafe impl Send for Command {}
-
 impl Command {
-    #[must_use]
-    pub fn along_with(self, other: Self) -> Self {
-        Self::Parallel(ParallelBuiltCommand {
+    pub fn along_with(self, other: Command) -> Command {
+        Command::Parallel(ParallelBuiltCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -593,24 +588,23 @@ impl Command {
         })
     }
 
-    #[must_use]
-    pub fn along_with_many(self, others: Vec<Self>) -> Self {
+    pub fn along_with_many(self, others: Vec<Command>) -> Command {
         let mut commands = vec![self];
         commands.extend(others);
-        Self::Parallel(ParallelBuiltCommand {
+        Command::Parallel(ParallelBuiltCommand {
             finished: vec![false; commands.len()],
             requirements: commands
                 .iter()
-                .flat_map(command::commands::CommandTrait::get_requirements)
+                .map(|command| command.get_requirements())
+                .flatten()
                 .collect(),
             commands,
             race: false,
         })
     }
 
-    #[must_use]
-    pub fn race_with(self, other: Self) -> Self {
-        Self::Parallel(ParallelBuiltCommand {
+    pub fn race_with(self, other: Command) -> Command {
+        Command::Parallel(ParallelBuiltCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -622,24 +616,23 @@ impl Command {
         })
     }
 
-    #[must_use]
-    pub fn race_with_many(self, others: Vec<Self>) -> Self {
+    pub fn race_with_many(self, others: Vec<Command>) -> Command {
         let mut commands = vec![self];
         commands.extend(others);
-        Self::Parallel(ParallelBuiltCommand {
+        Command::Parallel(ParallelBuiltCommand {
             finished: vec![false; commands.len()],
             requirements: commands
                 .iter()
-                .flat_map(command::commands::CommandTrait::get_requirements)
+                .map(|command| command.get_requirements())
+                .flatten()
                 .collect(),
             commands,
             race: true,
         })
     }
 
-    #[must_use]
-    pub fn before(self, other: Self) -> Self {
-        Self::Sequential(SequentialCommand {
+    pub fn before(self, other: Command) -> Command {
+        Command::Sequential(SequentialCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -650,9 +643,8 @@ impl Command {
         })
     }
 
-    #[must_use]
-    pub fn after(self, other: Self) -> Self {
-        Self::Sequential(SequentialCommand {
+    pub fn after(self, other: Command) -> Command {
+        Command::Sequential(SequentialCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -663,48 +655,44 @@ impl Command {
         })
     }
 
-    #[must_use]
-    pub fn and_then_many(self, others: Vec<Self>) -> Self {
+    pub fn and_then_many(self, others: Vec<Command>) -> Command {
         let mut commands = vec![self];
         commands.extend(others);
-        Self::Sequential(SequentialCommand {
+        Command::Sequential(SequentialCommand {
             requirements: commands
                 .iter()
-                .flat_map(command::commands::CommandTrait::get_requirements)
+                .map(|command| command.get_requirements())
+                .flatten()
                 .collect(),
             commands,
             current: 0,
         })
     }
 
-    #[must_use]
-    pub fn with_name(self, name: &str) -> Self {
-        Self::Named(NamedCommand {
+    pub fn with_name(self, name: &str) -> Command {
+        Command::Named(NamedCommand {
             name: String::from(name),
             command: Box::new(self),
         })
     }
 
-    #[must_use]
-    pub fn wait_for(self, seconds: f64) -> Self {
-        Self::Wait(WaitCommand {
+    pub fn wait_for(self, seconds: f64) -> Command {
+        Command::Wait(WaitCommand {
             duration: std::time::Duration::from_secs_f64(seconds),
             start_instant: None,
         })
     }
 
-    #[must_use]
-    pub fn custom(command: Box<dyn CommandTrait + Send>) -> Self {
-        Self::Custom(command)
+    pub fn custom(command: Box<dyn CommandTrait + Send>) -> Command {
+        Command::Custom(command)
     }
 
-    #[must_use]
-    pub fn empty() -> Self {
+    pub fn empty() -> Command {
         CommandBuilder::start_only(|| {}, vec![])
     }
 }
 impl Default for Command {
     fn default() -> Self {
-        Self::empty()
+        Command::empty()
     }
 }

--- a/wpilib/src/command/commands.rs
+++ b/wpilib/src/command/commands.rs
@@ -11,9 +11,9 @@ pub trait CommandTrait {
         false
     }
 
-    // fn add_requirements(&mut self, _subsystems: Vec<usize>) {}
+    // fn add_requirements(&mut self, _subsystems: Vec<u8>) {}
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         Vec::new()
     }
 
@@ -36,7 +36,7 @@ pub struct CommandBuilder {
     periodic: Option<Box<dyn FnMut()>>,
     end: Option<Box<dyn FnMut(bool)>>,
     is_finished: Option<Box<dyn FnMut() -> bool>>,
-    requirements: Vec<usize>,
+    requirements: Vec<u8>,
 }
 
 impl CommandBuilder {
@@ -70,7 +70,7 @@ impl CommandBuilder {
         self
     }
 
-    pub fn with_requirements(mut self, requirements: Vec<usize>) -> Self {
+    pub fn with_requirements(mut self, requirements: Vec<u8>) -> Self {
         self.requirements = requirements;
         self
     }
@@ -87,21 +87,21 @@ impl CommandBuilder {
 }
 
 impl CommandBuilder {
-    pub fn start_only(init: impl FnMut() + 'static, requirements: Vec<usize>) -> Command {
+    pub fn start_only(init: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
         CommandBuilder::new()
             .init(init)
             .with_requirements(requirements)
             .build()
     }
 
-    pub fn run_only(periodic: impl FnMut() + 'static, requirements: Vec<usize>) -> Command {
+    pub fn run_only(periodic: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
         CommandBuilder::new()
             .periodic(periodic)
             .with_requirements(requirements)
             .build()
     }
 
-    pub fn end_only(end: impl FnMut(bool) + 'static, requirements: Vec<usize>) -> Command {
+    pub fn end_only(end: impl FnMut(bool) + 'static, requirements: Vec<u8>) -> Command {
         CommandBuilder::new()
             .end(end)
             .with_requirements(requirements)
@@ -111,7 +111,7 @@ impl CommandBuilder {
     pub fn run_start(
         init: impl FnMut() + 'static,
         periodic: impl FnMut() + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .init(init)
@@ -123,7 +123,7 @@ impl CommandBuilder {
     pub fn run_end(
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .periodic(periodic)
@@ -135,7 +135,7 @@ impl CommandBuilder {
     pub fn start_end(
         init: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .init(init)
@@ -148,7 +148,7 @@ impl CommandBuilder {
         init: impl FnMut() + 'static,
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .init(init)
@@ -161,7 +161,7 @@ impl CommandBuilder {
     pub fn run_until(
         is_finished: impl FnMut() -> bool + 'static,
         periodic: impl FnMut() + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .is_finished(is_finished)
@@ -174,7 +174,7 @@ impl CommandBuilder {
         is_finished: impl FnMut() -> bool + 'static,
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .is_finished(is_finished)
@@ -187,7 +187,7 @@ impl CommandBuilder {
     pub fn start_run_until(
         init: impl FnMut() + 'static,
         is_finished: impl FnMut() -> bool + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .init(init)
@@ -201,7 +201,7 @@ impl CommandBuilder {
         periodic: impl FnMut() + 'static,
         end: impl FnMut(bool) + 'static,
         is_finished: impl FnMut() -> bool + 'static,
-        requirements: Vec<usize>,
+        requirements: Vec<u8>,
     ) -> Command {
         CommandBuilder::new()
             .init(init)
@@ -218,7 +218,7 @@ pub struct SimpleBuiltCommand {
     periodic: Option<Box<dyn FnMut()>>,
     end: Option<Box<dyn FnMut(bool)>>,
     is_finished: Option<Box<dyn FnMut() -> bool>>,
-    requirements: Vec<usize>,
+    requirements: Vec<u8>,
 }
 impl CommandTrait for SimpleBuiltCommand {
     fn init(&mut self) {
@@ -247,7 +247,7 @@ impl CommandTrait for SimpleBuiltCommand {
         }
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         self.requirements.clone()
     }
 }
@@ -267,7 +267,7 @@ impl Debug for SimpleBuiltCommand {
 pub struct ParallelBuiltCommand {
     commands: Vec<Command>,
     finished: Vec<bool>,
-    requirements: HashSet<usize>,
+    requirements: HashSet<u8>,
     race: bool,
 }
 impl CommandTrait for ParallelBuiltCommand {
@@ -308,7 +308,7 @@ impl CommandTrait for ParallelBuiltCommand {
         }
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         self.requirements.clone().into_iter().collect()
     }
 
@@ -326,7 +326,7 @@ impl CommandTrait for ParallelBuiltCommand {
 pub struct SequentialCommand {
     commands: Vec<Command>,
     current: usize,
-    requirements: HashSet<usize>,
+    requirements: HashSet<u8>,
 }
 impl CommandTrait for SequentialCommand {
     fn init(&mut self) {
@@ -356,7 +356,7 @@ impl CommandTrait for SequentialCommand {
         self.current >= self.commands.len()
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         self.requirements.clone().into_iter().collect()
     }
 
@@ -393,7 +393,7 @@ impl CommandTrait for ProxyCommand {
         self.command.as_mut().unwrap().is_finished()
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         self.command.as_ref().unwrap().get_requirements()
     }
 
@@ -432,7 +432,7 @@ impl CommandTrait for WaitCommand {
         self.start_instant.unwrap().elapsed() >= self.duration
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         vec![]
     }
 
@@ -463,7 +463,7 @@ impl CommandTrait for NamedCommand {
         self.command.is_finished()
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         self.command.get_requirements()
     }
 
@@ -549,7 +549,7 @@ impl CommandTrait for Command {
         }
     }
 
-    fn get_requirements(&self) -> Vec<usize> {
+    fn get_requirements(&self) -> Vec<u8> {
         match self {
             Command::Parallel(command) => command.get_requirements(),
             Command::Sequential(command) => command.get_requirements(),

--- a/wpilib/src/command/commands.rs
+++ b/wpilib/src/command/commands.rs
@@ -1,3 +1,4 @@
+use crate::command;
 use std::{collections::HashSet, fmt::Debug};
 
 pub trait CommandTrait {
@@ -40,7 +41,8 @@ pub struct CommandBuilder {
 }
 
 impl CommandBuilder {
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         Self {
             init: None,
             periodic: None,
@@ -50,31 +52,37 @@ impl CommandBuilder {
         }
     }
 
+    #[must_use]
     pub fn init(mut self, init: impl FnMut() + 'static) -> Self {
         self.init = Some(Box::new(init));
         self
     }
 
+    #[must_use]
     pub fn periodic(mut self, periodic: impl FnMut() + 'static) -> Self {
         self.periodic = Some(Box::new(periodic));
         self
     }
 
+    #[must_use]
     pub fn end(mut self, end: impl FnMut(bool) + 'static) -> Self {
         self.end = Some(Box::new(end));
         self
     }
 
+    #[must_use]
     pub fn is_finished(mut self, is_finished: impl FnMut() -> bool + 'static) -> Self {
         self.is_finished = Some(Box::new(is_finished));
         self
     }
 
+    #[must_use]
     pub fn with_requirements(mut self, requirements: Vec<u8>) -> Self {
         self.requirements = requirements;
         self
     }
 
+    #[must_use]
     pub fn build(self) -> Command {
         Command::Simple(SimpleBuiltCommand {
             init: self.init,
@@ -88,24 +96,21 @@ impl CommandBuilder {
 
 impl CommandBuilder {
     pub fn start_only(init: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .with_requirements(requirements)
             .build()
     }
 
     pub fn run_only(periodic: impl FnMut() + 'static, requirements: Vec<u8>) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .periodic(periodic)
             .with_requirements(requirements)
             .build()
     }
 
     pub fn end_only(end: impl FnMut(bool) + 'static, requirements: Vec<u8>) -> Command {
-        CommandBuilder::new()
-            .end(end)
-            .with_requirements(requirements)
-            .build()
+        Self::new().end(end).with_requirements(requirements).build()
     }
 
     pub fn run_start(
@@ -113,7 +118,7 @@ impl CommandBuilder {
         periodic: impl FnMut() + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .periodic(periodic)
             .with_requirements(requirements)
@@ -125,7 +130,7 @@ impl CommandBuilder {
         end: impl FnMut(bool) + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .periodic(periodic)
             .end(end)
             .with_requirements(requirements)
@@ -137,7 +142,7 @@ impl CommandBuilder {
         end: impl FnMut(bool) + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .end(end)
             .with_requirements(requirements)
@@ -150,7 +155,7 @@ impl CommandBuilder {
         end: impl FnMut(bool) + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .periodic(periodic)
             .end(end)
@@ -163,7 +168,7 @@ impl CommandBuilder {
         periodic: impl FnMut() + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .is_finished(is_finished)
             .periodic(periodic)
             .with_requirements(requirements)
@@ -176,7 +181,7 @@ impl CommandBuilder {
         end: impl FnMut(bool) + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .is_finished(is_finished)
             .periodic(periodic)
             .end(end)
@@ -189,7 +194,7 @@ impl CommandBuilder {
         is_finished: impl FnMut() -> bool + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .is_finished(is_finished)
             .with_requirements(requirements)
@@ -203,7 +208,7 @@ impl CommandBuilder {
         is_finished: impl FnMut() -> bool + 'static,
         requirements: Vec<u8>,
     ) -> Command {
-        CommandBuilder::new()
+        Self::new()
             .init(init)
             .periodic(periodic)
             .end(end)
@@ -240,11 +245,9 @@ impl CommandTrait for SimpleBuiltCommand {
     }
 
     fn is_finished(&mut self) -> bool {
-        if let Some(is_finished) = self.is_finished.as_mut() {
-            is_finished()
-        } else {
-            false
-        }
+        self.is_finished
+            .as_mut()
+            .map_or(false, |is_finished| is_finished())
     }
 
     fn get_requirements(&self) -> Vec<u8> {
@@ -272,7 +275,7 @@ pub struct ParallelBuiltCommand {
 }
 impl CommandTrait for ParallelBuiltCommand {
     fn init(&mut self) {
-        for command in self.commands.iter_mut() {
+        for command in &mut self.commands {
             command.init();
         }
     }
@@ -301,10 +304,10 @@ impl CommandTrait for ParallelBuiltCommand {
     }
 
     fn is_finished(&mut self) -> bool {
-        if !self.race {
-            self.finished.iter().all(|&finished| finished)
-        } else {
+        if self.race {
             self.finished.iter().any(|&finished| finished)
+        } else {
+            self.finished.iter().all(|&finished| finished)
         }
     }
 
@@ -315,7 +318,7 @@ impl CommandTrait for ParallelBuiltCommand {
     fn get_name(&self) -> String {
         self.commands
             .iter()
-            .map(|command| command.get_name())
+            .map(command::commands::CommandTrait::get_name)
             .collect::<Vec<_>>()
             .join(",")
     }
@@ -346,9 +349,9 @@ impl CommandTrait for SequentialCommand {
 
     fn end(&mut self, interrupted: bool) {
         if interrupted {
-            self.commands
-                .get_mut(self.current)
-                .map(|command| command.end(true));
+            if let Some(command) = self.commands.get_mut(self.current) {
+                command.end(true)
+            }
         }
     }
 
@@ -363,7 +366,7 @@ impl CommandTrait for SequentialCommand {
     fn get_name(&self) -> String {
         self.commands
             .iter()
-            .map(|command| command.get_name())
+            .map(command::commands::CommandTrait::get_name)
             .collect::<Vec<_>>()
             .join("->")
     }
@@ -484,99 +487,101 @@ pub enum Command {
 impl Debug for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            Command::Parallel(command) => f
+            Self::Parallel(command) => f
                 .debug_struct("Parallel")
                 .field("command", command)
                 .finish(),
-            Command::Sequential(command) => f
+            Self::Sequential(command) => f
                 .debug_struct("Sequential")
                 .field("command", command)
                 .finish(),
-            Command::Simple(command) => f.debug_struct("Simple").field("command", command).finish(),
-            Command::Custom(_) => f.debug_struct("Custom").finish(),
-            Command::Named(command) => f.debug_struct("Named").field("command", command).finish(),
-            Command::Wait(command) => f.debug_struct("Wait").field("command", command).finish(),
-            Command::Proxy(command) => f.debug_struct("Proxy").field("command", command).finish(),
+            Self::Simple(command) => f.debug_struct("Simple").field("command", command).finish(),
+            Self::Custom(_) => f.debug_struct("Custom").finish(),
+            Self::Named(command) => f.debug_struct("Named").field("command", command).finish(),
+            Self::Wait(command) => f.debug_struct("Wait").field("command", command).finish(),
+            Self::Proxy(command) => f.debug_struct("Proxy").field("command", command).finish(),
         }
     }
 }
 impl CommandTrait for Command {
     fn init(&mut self) {
         match self {
-            Command::Parallel(command) => command.init(),
-            Command::Sequential(command) => command.init(),
-            Command::Simple(command) => command.init(),
-            Command::Custom(command) => command.init(),
-            Command::Named(command) => command.init(),
-            Command::Wait(command) => command.init(),
-            Command::Proxy(command) => command.init(),
+            Self::Parallel(command) => command.init(),
+            Self::Sequential(command) => command.init(),
+            Self::Simple(command) => command.init(),
+            Self::Custom(command) => command.init(),
+            Self::Named(command) => command.init(),
+            Self::Wait(command) => command.init(),
+            Self::Proxy(command) => command.init(),
         }
     }
 
     fn periodic(&mut self) {
         match self {
-            Command::Parallel(command) => command.periodic(),
-            Command::Sequential(command) => command.periodic(),
-            Command::Simple(command) => command.periodic(),
-            Command::Custom(command) => command.periodic(),
-            Command::Named(command) => command.periodic(),
-            Command::Wait(command) => command.periodic(),
-            Command::Proxy(command) => command.periodic(),
+            Self::Parallel(command) => command.periodic(),
+            Self::Sequential(command) => command.periodic(),
+            Self::Simple(command) => command.periodic(),
+            Self::Custom(command) => command.periodic(),
+            Self::Named(command) => command.periodic(),
+            Self::Wait(command) => command.periodic(),
+            Self::Proxy(command) => command.periodic(),
         }
     }
 
     fn end(&mut self, interrupted: bool) {
         match self {
-            Command::Parallel(command) => command.end(interrupted),
-            Command::Sequential(command) => command.end(interrupted),
-            Command::Simple(command) => command.end(interrupted),
-            Command::Custom(command) => command.end(interrupted),
-            Command::Named(command) => command.end(interrupted),
-            Command::Wait(command) => command.end(interrupted),
-            Command::Proxy(command) => command.end(interrupted),
+            Self::Parallel(command) => command.end(interrupted),
+            Self::Sequential(command) => command.end(interrupted),
+            Self::Simple(command) => command.end(interrupted),
+            Self::Custom(command) => command.end(interrupted),
+            Self::Named(command) => command.end(interrupted),
+            Self::Wait(command) => command.end(interrupted),
+            Self::Proxy(command) => command.end(interrupted),
         }
     }
 
     fn is_finished(&mut self) -> bool {
         match self {
-            Command::Parallel(command) => command.is_finished(),
-            Command::Sequential(command) => command.is_finished(),
-            Command::Simple(command) => command.is_finished(),
-            Command::Custom(command) => command.is_finished(),
-            Command::Named(command) => command.is_finished(),
-            Command::Wait(command) => command.is_finished(),
-            Command::Proxy(command) => command.is_finished(),
+            Self::Parallel(command) => command.is_finished(),
+            Self::Sequential(command) => command.is_finished(),
+            Self::Simple(command) => command.is_finished(),
+            Self::Custom(command) => command.is_finished(),
+            Self::Named(command) => command.is_finished(),
+            Self::Wait(command) => command.is_finished(),
+            Self::Proxy(command) => command.is_finished(),
         }
     }
 
     fn get_requirements(&self) -> Vec<u8> {
         match self {
-            Command::Parallel(command) => command.get_requirements(),
-            Command::Sequential(command) => command.get_requirements(),
-            Command::Simple(command) => command.get_requirements(),
-            Command::Custom(command) => command.get_requirements(),
-            Command::Named(command) => command.get_requirements(),
-            Command::Wait(command) => command.get_requirements(),
-            Command::Proxy(command) => command.get_requirements(),
+            Self::Parallel(command) => command.get_requirements(),
+            Self::Sequential(command) => command.get_requirements(),
+            Self::Simple(command) => command.get_requirements(),
+            Self::Custom(command) => command.get_requirements(),
+            Self::Named(command) => command.get_requirements(),
+            Self::Wait(command) => command.get_requirements(),
+            Self::Proxy(command) => command.get_requirements(),
         }
     }
 
     fn get_name(&self) -> String {
         match self {
-            Command::Parallel(command) => command.get_name(),
-            Command::Sequential(command) => command.get_name(),
-            Command::Simple(command) => command.get_name(),
-            Command::Custom(command) => command.get_name(),
-            Command::Named(command) => command.get_name(),
-            Command::Wait(command) => command.get_name(),
-            Command::Proxy(command) => command.get_name(),
+            Self::Parallel(command) => command.get_name(),
+            Self::Sequential(command) => command.get_name(),
+            Self::Simple(command) => command.get_name(),
+            Self::Custom(command) => command.get_name(),
+            Self::Named(command) => command.get_name(),
+            Self::Wait(command) => command.get_name(),
+            Self::Proxy(command) => command.get_name(),
         }
     }
 }
 unsafe impl Send for Command {}
+
 impl Command {
-    pub fn along_with(self, other: Command) -> Command {
-        Command::Parallel(ParallelBuiltCommand {
+    #[must_use]
+    pub fn along_with(self, other: Self) -> Self {
+        Self::Parallel(ParallelBuiltCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -588,23 +593,24 @@ impl Command {
         })
     }
 
-    pub fn along_with_many(self, others: Vec<Command>) -> Command {
+    #[must_use]
+    pub fn along_with_many(self, others: Vec<Self>) -> Self {
         let mut commands = vec![self];
         commands.extend(others);
-        Command::Parallel(ParallelBuiltCommand {
+        Self::Parallel(ParallelBuiltCommand {
             finished: vec![false; commands.len()],
             requirements: commands
                 .iter()
-                .map(|command| command.get_requirements())
-                .flatten()
+                .flat_map(command::commands::CommandTrait::get_requirements)
                 .collect(),
             commands,
             race: false,
         })
     }
 
-    pub fn race_with(self, other: Command) -> Command {
-        Command::Parallel(ParallelBuiltCommand {
+    #[must_use]
+    pub fn race_with(self, other: Self) -> Self {
+        Self::Parallel(ParallelBuiltCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -616,23 +622,24 @@ impl Command {
         })
     }
 
-    pub fn race_with_many(self, others: Vec<Command>) -> Command {
+    #[must_use]
+    pub fn race_with_many(self, others: Vec<Self>) -> Self {
         let mut commands = vec![self];
         commands.extend(others);
-        Command::Parallel(ParallelBuiltCommand {
+        Self::Parallel(ParallelBuiltCommand {
             finished: vec![false; commands.len()],
             requirements: commands
                 .iter()
-                .map(|command| command.get_requirements())
-                .flatten()
+                .flat_map(command::commands::CommandTrait::get_requirements)
                 .collect(),
             commands,
             race: true,
         })
     }
 
-    pub fn before(self, other: Command) -> Command {
-        Command::Sequential(SequentialCommand {
+    #[must_use]
+    pub fn before(self, other: Self) -> Self {
+        Self::Sequential(SequentialCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -643,8 +650,9 @@ impl Command {
         })
     }
 
-    pub fn after(self, other: Command) -> Command {
-        Command::Sequential(SequentialCommand {
+    #[must_use]
+    pub fn after(self, other: Self) -> Self {
+        Self::Sequential(SequentialCommand {
             requirements: self
                 .get_requirements()
                 .into_iter()
@@ -655,44 +663,48 @@ impl Command {
         })
     }
 
-    pub fn and_then_many(self, others: Vec<Command>) -> Command {
+    #[must_use]
+    pub fn and_then_many(self, others: Vec<Self>) -> Self {
         let mut commands = vec![self];
         commands.extend(others);
-        Command::Sequential(SequentialCommand {
+        Self::Sequential(SequentialCommand {
             requirements: commands
                 .iter()
-                .map(|command| command.get_requirements())
-                .flatten()
+                .flat_map(command::commands::CommandTrait::get_requirements)
                 .collect(),
             commands,
             current: 0,
         })
     }
 
-    pub fn with_name(self, name: &str) -> Command {
-        Command::Named(NamedCommand {
+    #[must_use]
+    pub fn with_name(self, name: &str) -> Self {
+        Self::Named(NamedCommand {
             name: String::from(name),
             command: Box::new(self),
         })
     }
 
-    pub fn wait_for(self, seconds: f64) -> Command {
-        Command::Wait(WaitCommand {
+    #[must_use]
+    pub fn wait_for(self, seconds: f64) -> Self {
+        Self::Wait(WaitCommand {
             duration: std::time::Duration::from_secs_f64(seconds),
             start_instant: None,
         })
     }
 
-    pub fn custom(command: Box<dyn CommandTrait + Send>) -> Command {
-        Command::Custom(command)
+    #[must_use]
+    pub fn custom(command: Box<dyn CommandTrait + Send>) -> Self {
+        Self::Custom(command)
     }
 
-    pub fn empty() -> Command {
+    #[must_use]
+    pub fn empty() -> Self {
         CommandBuilder::start_only(|| {}, vec![])
     }
 }
 impl Default for Command {
     fn default() -> Self {
-        Command::empty()
+        Self::empty()
     }
 }

--- a/wpilib/src/command/conditions.rs
+++ b/wpilib/src/command/conditions.rs
@@ -1,0 +1,90 @@
+use super::manager::*;
+use std::sync::Arc;
+#[derive(Clone)]
+pub struct OnTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    pub function: Arc<T>,
+    pub last_state: bool,
+}
+
+impl<T> Condition for OnTrue<T> 
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn get_condition(&mut self) -> ConditionResponse {
+        let state = (self.function)();
+        if state == true && self.last_state == false {
+            self.last_state = state;
+            return ConditionResponse::Start;
+        }
+        self.last_state = state;
+        ConditionResponse::NoChange
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Condition> {
+        Box::new(
+            Self{
+                function: self.function.clone(),
+                last_state: self.last_state.clone()
+            }
+        )
+    }
+
+}
+
+impl<T> std::fmt::Debug for OnTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnTrue")
+            .field("last_state", &self.last_state)
+            .finish()
+        
+    }
+}
+
+
+
+#[derive(Clone)]
+pub struct WhileTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    pub function: Arc<T>,
+    pub last_state: bool,
+}
+
+impl<T> Condition for WhileTrue<T> 
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn get_condition(&mut self) -> ConditionResponse {
+        let state = (self.function)();
+        if state == true && self.last_state == false {
+            self.last_state = state;
+            return ConditionResponse::Start;
+        } else if state == true {
+            self.last_state = state;
+            return ConditionResponse::Continue
+        } else if state == false && self.last_state == true{
+            self.last_state = state;
+            return ConditionResponse::Stop
+        }
+
+        self.last_state = state;
+        ConditionResponse::NoChange
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Condition> {
+        Box::new(
+            Self{
+                function: self.function.clone(),
+                last_state: self.last_state.clone()
+            }
+        )
+    }
+
+}
+
+impl<T> std::fmt::Debug for WhileTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnTrue")
+            .field("last_state", &self.last_state)
+            .finish()
+        
+    }
+}

--- a/wpilib/src/command/conditions.rs
+++ b/wpilib/src/command/conditions.rs
@@ -88,3 +88,23 @@ impl<T> std::fmt::Debug for WhileTrue<T>
         
     }
 }
+
+pub fn on_true<T>(f: T) -> OnTrue<impl Fn() -> bool + Send + Sync + 'static>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    OnTrue{function: Arc::new(f), last_state: false}
+}
+
+pub fn on_false<T, F>(f: T) -> OnTrue<impl Fn() -> bool + Send + Sync + 'static>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    OnTrue{function: Arc::new(move || { !f() }), last_state: false}
+}
+
+pub fn while_true<T>(f: T) -> WhileTrue<impl Fn() -> bool + Send + Sync + 'static>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    WhileTrue{function: Arc::new(f), last_state: false}
+}
+
+pub fn while_false<T>(f: T) -> WhileTrue<impl Fn() -> bool + Send + Sync + 'static>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    WhileTrue{function: Arc::new(move || { !f() }), last_state: false}
+}

--- a/wpilib/src/command/manager.rs
+++ b/wpilib/src/command/manager.rs
@@ -1,4 +1,4 @@
-use std::{collections::{HashMap, HashSet}, ops::Deref, sync::Arc};
+use std::{collections::{HashMap, HashSet}, ops::Deref};
 
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -242,94 +242,7 @@ impl Clone for Box<dyn Condition>{
     }
 }
 
-#[derive(Clone)]
-pub struct OnTrue<T>
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    pub function: Arc<T>,
-    pub last_state: bool,
-}
 
-impl<T> Condition for OnTrue<T> 
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    fn get_condition(&mut self) -> ConditionResponse {
-        let state = (self.function)();
-        if state == true && self.last_state == false {
-            self.last_state = state;
-            return ConditionResponse::Start;
-        }
-        self.last_state = state;
-        ConditionResponse::NoChange
-    }
-
-    fn clone_boxed(&self) -> Box<dyn Condition> {
-        Box::new(
-            Self{
-                function: self.function.clone(),
-                last_state: self.last_state.clone()
-            }
-        )
-    }
-
-}
-
-impl<T> std::fmt::Debug for OnTrue<T>
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OnTrue")
-            .field("last_state", &self.last_state)
-            .finish()
-        
-    }
-}
-
-
-
-#[derive(Clone)]
-pub struct WhileTrue<T>
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    pub function: Arc<T>,
-    pub last_state: bool,
-}
-
-impl<T> Condition for WhileTrue<T> 
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    fn get_condition(&mut self) -> ConditionResponse {
-        let state = (self.function)();
-        if state == true && self.last_state == false {
-            self.last_state = state;
-            return ConditionResponse::Start;
-        } else if state == true {
-            self.last_state = state;
-            return ConditionResponse::Continue
-        } else if state == false && self.last_state == true{
-            self.last_state = state;
-            return ConditionResponse::Stop
-        }
-
-        self.last_state = state;
-        ConditionResponse::NoChange
-    }
-
-    fn clone_boxed(&self) -> Box<dyn Condition> {
-        Box::new(
-            Self{
-                function: self.function.clone(),
-                last_state: self.last_state.clone()
-            }
-        )
-    }
-
-}
-
-impl<T> std::fmt::Debug for WhileTrue<T>
-    where T:  Fn() -> bool + Send + Sync + 'static{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OnTrue")
-            .field("last_state", &self.last_state)
-            .finish()
-        
-    }
-}
 #[derive(Clone)]
 pub struct ConditionalScheduler {
     active_commands: HashMap<usize, CommandIndex>,

--- a/wpilib/src/command/manager.rs
+++ b/wpilib/src/command/manager.rs
@@ -7,14 +7,20 @@ use super::{commands::CommandTrait, Command};
 
 static MANAGER: Mutex<Lazy<CommandManager>> = Mutex::new(Lazy::new(CommandManager::new));
 
-type CommandIndex = usize;
-type SubsystemSUID = u8;
+type SubsystemSUID = usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommandIndex {
+    DefaultCommand(usize),
+    Command(usize)
+}
 
 pub struct CommandManager {
     periodic_callbacks: Vec<fn()>,
     commands: Vec<Option<Command>>,
     interrupt_state: HashMap<CommandIndex, bool>,
-    default_commands: HashMap<SubsystemSUID, CommandIndex>,
+    default_commands: Vec<Option<Command>>,
+    subsystem_to_default: HashMap<SubsystemSUID, CommandIndex>,
     requirements: HashMap<SubsystemSUID, CommandIndex>,
     initialized_commands: HashSet<CommandIndex>,
     orphaned_commands: HashSet<CommandIndex>,
@@ -40,7 +46,8 @@ impl CommandManager {
             periodic_callbacks: Vec::new(),
             commands: Vec::new(),
             interrupt_state: HashMap::new(),
-            default_commands: HashMap::new(),
+            default_commands: Vec::new(),
+            subsystem_to_default: HashMap::new(),
             requirements: HashMap::new(),
             initialized_commands: HashSet::new(),
             orphaned_commands: HashSet::new(),
@@ -48,15 +55,19 @@ impl CommandManager {
         }
     }
 
-    pub fn register_subsystem(suid: u8, periodic_callback: fn(), default_command: Option<Command>) {
+    pub fn register_subsystem(suid: SubsystemSUID, periodic_callback: fn(), default_command: Option<Command>) {
         let mut scheduler = MANAGER.lock();
         scheduler
             .periodic_callbacks
             .push(periodic_callback);
-        let cmd_idx = scheduler.add_command(default_command.unwrap_or_default());
-        scheduler.default_commands.insert(suid, cmd_idx);
+        scheduler.default_commands.push(default_command);
+        let idx = scheduler.default_commands.len() - 1;
+        scheduler.subsystem_to_default.insert(suid, CommandIndex::DefaultCommand(idx));
+        scheduler.interrupt_state.insert(CommandIndex::DefaultCommand(idx), false);
+        
         drop(scheduler);
     }
+
 
     /// Will run all periodic callbacks, run all conditional schedulers, init all un-initialized commands, and run all commands
     /// in that order.
@@ -71,7 +82,7 @@ impl CommandManager {
         for callback in &self.periodic_callbacks {
             callback();
         }
-        for (suid, cmd_idx) in &self.default_commands {
+        for (suid, cmd_idx) in &self.subsystem_to_default {
             if !self.requirements.contains_key(suid) {
                 self.requirements.insert(*suid, *cmd_idx);
             }
@@ -88,12 +99,15 @@ impl CommandManager {
     }
 
     fn run_commands(&mut self) {
-        let mut to_remove: Vec<CommandIndex> = Vec::new();
+        let mut to_remove: Vec<usize> = Vec::new();
         let mut cmds = self.requirements.values().collect::<Vec<&CommandIndex>>();
         cmds.extend(self.orphaned_commands.iter());
 
         for index in cmds {
-            if let Some(command) = self.commands[*index].as_mut() {
+            if let Some(command) = match index {
+                CommandIndex::Command(cmd) => &mut self.commands[*cmd],
+                CommandIndex::DefaultCommand(cmd) => &mut self.default_commands[*cmd]
+            } {
                 if !self.initialized_commands.contains(index) {
                     command.init();
                     self.initialized_commands.insert(*index);
@@ -101,26 +115,30 @@ impl CommandManager {
                 command.periodic();
                 if command.is_finished() {
                     command.end(false);
-                    to_remove.push(*index);
+                    match *index {
+                        CommandIndex::Command(idx) => to_remove.push(idx),
+                        CommandIndex::DefaultCommand(_) => {}
+                    }
                 }
                 if self.interrupt_state[index]{
                     command.end(true);
-                    to_remove.push(*index);
+                    match *index {
+                        CommandIndex::Command(idx) => to_remove.push(idx),
+                        CommandIndex::DefaultCommand(_) => {}
+                    }
                 }
             }
         }
         for index in to_remove {
-            self.initialized_commands.remove(&index);
+            self.initialized_commands.remove(&CommandIndex::Command(index));
             if let Some(cmd) = self.commands.remove(index) {
                 let requirements = cmd.get_requirements();
                 if requirements.is_empty() {
-                    self.orphaned_commands.remove(&index);
+                    self.orphaned_commands.remove(&CommandIndex::Command(index));
                 } else {
                     for req in cmd.get_requirements() {
                         self.requirements.remove(&req);
-                        if let Some(default) = self.default_commands.remove(&req) {
-                            self.requirements.insert(req, default);
-                        }
+                        self.requirements.insert(req, CommandIndex::DefaultCommand(req));
                     }
                 }
             }
@@ -130,12 +148,14 @@ impl CommandManager {
     fn add_command(&mut self, command: Command) -> CommandIndex {
         if let Some(index) = self.commands.iter().position(Option::is_none) {
             self.commands[index] = Some(command);
-            self.interrupt_state.insert(index, false);
-            index
+            let cmd_idx = CommandIndex::Command(index);
+            self.interrupt_state.insert(cmd_idx, false);
+            cmd_idx
         } else {
             self.commands.push(Some(command));
-            self.interrupt_state.insert(self.commands.len() - 1, false);
-            self.commands.len() - 1
+            let cmd_idx = CommandIndex::Command(self.commands.len() - 1);
+            self.interrupt_state.insert(cmd_idx, false);
+            cmd_idx
         }
     }
 
@@ -175,22 +195,36 @@ impl CommandManager {
 
     pub fn cancel_all() {
         let mut scheduler = MANAGER.lock();
+        for maybe_command in &mut scheduler.commands {
+            match maybe_command {
+                Some(command) => {
+                    command.end(true);
+                },
+                None => {}
+            }
+        }
         scheduler.commands.clear();
         scheduler.requirements.clear();
         scheduler.initialized_commands.clear();
         scheduler.orphaned_commands.clear();
+
+        
     }
 
     pub fn add_cond_scheduler(scheduler: ConditionalScheduler) {
         let mut manager = MANAGER.lock();
         manager.cond_schedulers.push(scheduler);
     }
+
+    pub fn clear_cond_schedulers(){
+        let mut manager = MANAGER.lock();
+        manager.cond_schedulers.clear();
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum ConditionResponse {
     Start,
-    Continue,
     Stop,
     NoChange,
 }
@@ -248,6 +282,49 @@ impl<T> std::fmt::Debug for OnTrue<T>
 
 
 #[derive(Clone)]
+pub struct WhileTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    pub function: Arc<T>,
+    pub last_state: bool,
+}
+
+impl<T> Condition for WhileTrue<T> 
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn get_condition(&mut self) -> ConditionResponse {
+        let state = (self.function)();
+        if state == true {
+            self.last_state = state;
+            return ConditionResponse::Start;
+        } else if state == false && self.last_state == true{
+            self.last_state = state;
+            return ConditionResponse::Stop
+        }
+
+        self.last_state = state;
+        ConditionResponse::NoChange
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Condition> {
+        Box::new(
+            Self{
+                function: self.function.clone(),
+                last_state: self.last_state.clone()
+            }
+        )
+    }
+
+}
+
+impl<T> std::fmt::Debug for WhileTrue<T>
+    where T:  Fn() -> bool + Send + Sync + 'static{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnTrue")
+            .field("last_state", &self.last_state)
+            .finish()
+        
+    }
+}
+#[derive(Clone)]
 pub struct ConditionalScheduler {
     active_commands: HashMap<usize, CommandIndex>,
     conds: Vec<(Box<dyn Condition>, fn() -> Command)>,
@@ -270,15 +347,11 @@ impl ConditionalScheduler {
 
             match condition_result{
                 ConditionResponse::Start => {
-                    let command = cmd();
-                    let cmd_idx = manager.cond_schedule(command);
-                    self.active_commands.insert(i, cmd_idx);
-                },
-                ConditionResponse::Continue => {
                     if !self.active_commands.contains_key(&i) {
                         let command = cmd();
                         let cmd_idx = manager.cond_schedule(command);
-                        self.active_commands.insert(i, cmd_idx);    
+                        println!("start"); 
+                        self.active_commands.insert(i, cmd_idx);
                     }
                 },
                 ConditionResponse::Stop => {
@@ -287,7 +360,9 @@ impl ConditionalScheduler {
                         self.active_commands.remove(&i);    
                     }
                 },
-                ConditionResponse::NoChange => {}
+                ConditionResponse::NoChange => {
+                    println!("no_change"); 
+                }
             }
         }
     }

--- a/wpilib/src/command/manager.rs
+++ b/wpilib/src/command/manager.rs
@@ -7,7 +7,7 @@ use super::{commands::CommandTrait, Command};
 
 static MANAGER: Mutex<Lazy<CommandManager>> = Mutex::new(Lazy::new(CommandManager::new));
 
-type SubsystemSUID = usize;
+type SubsystemSUID = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CommandIndex {
@@ -138,7 +138,8 @@ impl CommandManager {
                 } else {
                     for req in cmd.get_requirements() {
                         self.requirements.remove(&req);
-                        self.requirements.insert(req, CommandIndex::DefaultCommand(req));
+                        let idx = self.subsystem_to_default[&req];
+                        self.requirements.insert(req, idx);
                     }
                 }
             }

--- a/wpilib/src/command/mod.rs
+++ b/wpilib/src/command/mod.rs
@@ -2,9 +2,12 @@
 pub mod manager;
 pub mod command_hid;
 pub mod commands;
+pub mod conditions;
 #[cfg(test)]
 mod test;
 
 pub use commands::Command;
 pub use manager::CommandManager;
 pub use manager::ConditionalScheduler;
+pub use conditions::OnTrue;
+pub use conditions::WhileTrue;

--- a/wpilib/src/command/mod.rs
+++ b/wpilib/src/command/mod.rs
@@ -11,3 +11,7 @@ pub use manager::CommandManager;
 pub use manager::ConditionalScheduler;
 pub use conditions::OnTrue;
 pub use conditions::WhileTrue;
+pub use conditions::on_true;
+pub use conditions::on_false;
+pub use conditions::while_true;
+pub use conditions::while_false;

--- a/wpilib/src/command/test.rs
+++ b/wpilib/src/command/test.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
 
 use parking_lot::Mutex;
 use wpilib_macros::{subsystem, subsystem_methods};
 
 use crate::command::{
     commands::CommandTrait, manager::CommandManager, Command,
-    conditions::{OnTrue, WhileTrue},
+    conditions::{self},
     ConditionalScheduler,
 };
 
@@ -170,7 +169,7 @@ fn test_on_true() {
     TestSubsystem::reset();
     let mut scheduler = ConditionalScheduler::new();
     
-    let cond = OnTrue{function: Arc::new(|| true), last_state: false};
+    let cond = conditions::on_true(|| true);
     
     scheduler.add_cond(cond , || TestSubsystem::cmd_activate_motor());
 
@@ -209,7 +208,7 @@ fn test_while_true() {
     let mut scheduler = ConditionalScheduler::new();
     
     
-    let cond = WhileTrue{function: Arc::new(move || {get_state()}), last_state: false};
+    let cond = conditions::while_true(|| get_state());
     
     scheduler.add_cond(cond , || TestSubsystem::cmd_activate_motor());
 

--- a/wpilib/src/command/test.rs
+++ b/wpilib/src/command/test.rs
@@ -4,7 +4,8 @@ use parking_lot::Mutex;
 use wpilib_macros::{subsystem, subsystem_methods};
 
 use crate::command::{
-    commands::CommandTrait, manager::{CommandManager, OnTrue, WhileTrue}, Command,
+    commands::CommandTrait, manager::CommandManager, Command,
+    conditions::{OnTrue, WhileTrue},
     ConditionalScheduler,
 };
 


### PR DESCRIPTION
This pull request fixes a few bugs and adds Condition as a trait. The Condition trait represents the function and state for when a command starts and stops. This replaces the ConditionalScheduler's map that was originally intended to store this state. Examples are included in the test module.  The ConditionalScheduler also remembers what commands it has scheduled and what commands it has not so that it does not reschedule commands. 

Other things fixed in this pull request:  
 - So that default commands are no longer removed during a `cancel_all()` function call, they are stored in a `default_commands` vector. CommandIndex is now an enum, either a `Command`, which indexes into the old command list, or a `DefaultCommand` which indexes into `default_commands`
 - Tests now reset their static state, including subsystem and CommandManager